### PR TITLE
Retrieve Url params properly.

### DIFF
--- a/Hypermedia/Crawling/Crawler.php
+++ b/Hypermedia/Crawling/Crawler.php
@@ -130,8 +130,8 @@ class Crawler implements CrawlerInterface
             $parameters = explode('&', $parsedUrl['query']);
 
             foreach ($parameters as $parameter) {
-                list($name, $value) = explode('=', $parameter);
-                $params[$name] = $value;
+                preg_match('/(?<parameter_name>[^=]?)=(?<parameter_value>.*)/', $parameter, $matches);
+                $params[$matches['parameter_name']] = $matches['parameter_value'];
             }
         }
 


### PR DESCRIPTION
Before the fix, the url params were retrieved with a simple `explode`
on `=` symbol. When the parameter value has an `=`, it's a real prolem.
The `explode` is replaced by a regexp.