### PR TITLE
Match all characters before equals symbol.

### DIFF
--- a/Hypermedia/Crawling/Crawler.php
+++ b/Hypermedia/Crawling/Crawler.php
@@ -130,7 +130,7 @@ class Crawler implements CrawlerInterface
             $parameters = explode('&', $parsedUrl['query']);
 
             foreach ($parameters as $parameter) {
-                preg_match('/(?<parameter_name>[^=]?)=(?<parameter_value>.*)/', $parameter, $matches);
+                preg_match('/(?<parameter_name>[^=]+)=(?<parameter_value>.*)/', $parameter, $matches);
                 $params[$matches['parameter_name']] = $matches['parameter_value'];
             }
         }


### PR DESCRIPTION
There is a misunderstanding in regex for url params build.
Currently, the crawler will retrieve only one character of parameter
name. We need to change the regex quantifier to "+" to get one or more
characters instead of zero or one "?".