### PR TITLE
Change the way to match path.

### DIFF
--- a/Hypermedia/Crawling/CrawlingPath.php
+++ b/Hypermedia/Crawling/CrawlingPath.php
@@ -73,13 +73,10 @@ class CrawlingPath implements CrawlingPathInterface
      */
     public function matchPath($path)
     {
-        // Remove schemes.
-        $endpointRoot = strstr($this->getEndpointRoot(), '://');
-        $path = strstr($path, '://');
+        $endpointRootSchemeless = strstr($this->getEndpointRoot(), '://');
+        $pathSchemeless = strstr($path, '://');
 
-        $path = substr($path, 0, strlen($endpointRoot));
-
-        return $endpointRoot === $path;
+        return $endpointRootSchemeless === substr($pathSchemeless, 0, strlen($endpointRootSchemeless));
     }
 
     /**

--- a/Hypermedia/Crawling/CrawlingPath.php
+++ b/Hypermedia/Crawling/CrawlingPath.php
@@ -46,8 +46,7 @@ class CrawlingPath implements CrawlingPathInterface
     public function __construct(
         HypermediaHydratationHandlerInterface $hydratationHandler,
         RestApiClientInterface $apiClient
-    )
-    {
+    ) {
         $this->hydratationHandler = $hydratationHandler;
         $this->apiClient = $apiClient;
     }
@@ -74,9 +73,13 @@ class CrawlingPath implements CrawlingPathInterface
      */
     public function matchPath($path)
     {
-        $endpointRoot = $this->getEndpointRoot();
+        // Remove schemes.
+        $endpointRoot = strstr($this->getEndpointRoot(), '://');
+        $path = strstr($path, '://');
 
-        return $endpointRoot === substr($path, 0, strlen($endpointRoot));
+        $path = substr($path, 0, strlen($endpointRoot));
+
+        return $endpointRoot === $path;
     }
 
     /**


### PR DESCRIPTION
The crawling path "matchPath" method checks if the given url match
the crawling path endpoint.

When the scheme is different the method considers that urls are
different.

Now the urls are checked without the scheme.